### PR TITLE
LDBR 2.3: Внести правки в роутер после РК

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "plugins": ["unused-imports"],
   "env": {
     "browser": true,
     "es2021": true
@@ -20,6 +21,7 @@
     "linebreak-style": "off",
     "no-var": "error",
     "no-redeclare": "error",
+    "unused-imports/no-unused-imports": "error",
     "no-unused-vars": "warn",
     "max-len": ["error", { "code": 105 }],
     "no-irregular-whitespace": "off"

--- a/package-lock.json
+++ b/package-lock.json
@@ -447,6 +447,21 @@
             "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
             "integrity": "sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw=="
         },
+        "eslint-plugin-unused-imports": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-1.1.5.tgz",
+            "integrity": "sha512-TeV8l8zkLQrq9LBeYFCQmYVIXMjfHgdRQLw7dEZp4ZB3PeR10Y5Uif11heCsHRmhdRIYMoewr1d9ouUHLbLHew==",
+            "dev": true,
+            "requires": {
+                "eslint-rule-composer": "^0.3.0"
+            }
+        },
+        "eslint-rule-composer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+            "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+            "dev": true
+        },
         "eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "body-parser": "^1.18.3",
         "eslint": "^7.32.0",
         "eslint-config-google": "^0.14.0",
+        "eslint-plugin-unused-imports": "^1.1.5",
         "express": "^4.17.1",
         "handlebars": "^4.7.7",
         "morgan": "^1.9.1"

--- a/src/utils/Router/Router.js
+++ b/src/utils/Router/Router.js
@@ -46,7 +46,7 @@ class Router {
     start() {
         this._root.addEventListener('click', (event) => {
             const link = event.target.closest('a');
-            if (link instanceof HTMLAnchorElement) {
+            if (link) {
                 event.preventDefault();
                 this.go(link.pathname + link.search);
             }


### PR DESCRIPTION
В ветке содержатся небольшие правки к роутеру согласно замечаниям в РК: удален вызов `preventDefault`, комментарии к `pushState`, обработка событий от клика по содержимому `<a>`, более ясные имена методов роутера.
* Тикет в Trello [[2.3]](https://trello.com/c/jGB1URTZ/38-%D0%BF%D1%80%D0%B0%D0%B2%D0%BA%D0%B8-%D0%BA-%D1%80%D0%BE%D1%83%D1%82%D0%B5%D1%80%D1%83-23).